### PR TITLE
Add OnlyUp-style systems and auto course generation

### DIFF
--- a/Assets/Scripts/Checkpoint.cs
+++ b/Assets/Scripts/Checkpoint.cs
@@ -1,0 +1,49 @@
+using UnityEngine;
+
+[RequireComponent(typeof(Collider))]
+public class Checkpoint : MonoBehaviour
+{
+    [Header("Checkpoint Visuals")]
+    public Color inactiveColor = new Color(1f, 0.5f, 0f, 0.35f);
+    public Color activeColor = new Color(0.2f, 0.8f, 1f, 0.6f);
+
+    bool activated;
+
+    void Reset()
+    {
+        SetTrigger();
+    }
+
+    void OnValidate()
+    {
+        SetTrigger();
+    }
+
+    void SetTrigger()
+    {
+        var col = GetComponent<Collider>();
+        if (col != null)
+        {
+            col.isTrigger = true;
+        }
+    }
+
+    void OnTriggerEnter(Collider other)
+    {
+        var player = other.GetComponent<PlayerController>() ?? other.GetComponentInParent<PlayerController>();
+        if (player == null)
+        {
+            return;
+        }
+
+        player.respawnPoint = transform;
+        activated = true;
+    }
+
+    void OnDrawGizmos()
+    {
+        Gizmos.color = activated ? activeColor : inactiveColor;
+        Gizmos.matrix = transform.localToWorldMatrix;
+        Gizmos.DrawCube(Vector3.zero, Vector3.one);
+    }
+}

--- a/Assets/Scripts/EnsurePhysicsMaterials.cs
+++ b/Assets/Scripts/EnsurePhysicsMaterials.cs
@@ -1,0 +1,49 @@
+using UnityEngine;
+
+public class EnsurePhysicsMaterials : MonoBehaviour
+{
+    static PhysicMaterial iceMaterial;
+
+    [Tooltip("設定したColliderにPM_Iceを適用します。空なら自身を利用")] 
+    public Collider target;
+
+    void Awake()
+    {
+        if (target == null)
+        {
+            target = GetComponent<Collider>();
+        }
+
+        if (target != null)
+        {
+            ApplyIce(target);
+        }
+    }
+
+    public static PhysicMaterial GetIceMaterial()
+    {
+        if (iceMaterial == null)
+        {
+            iceMaterial = new PhysicMaterial("PM_Ice")
+            {
+                dynamicFriction = 0.1f,
+                staticFriction = 0.1f,
+                frictionCombine = PhysicMaterialCombine.Minimum,
+                bounceCombine = PhysicMaterialCombine.Minimum,
+                bounciness = 0f
+            };
+        }
+
+        return iceMaterial;
+    }
+
+    public static void ApplyIce(Collider collider)
+    {
+        if (collider == null)
+        {
+            return;
+        }
+
+        collider.material = GetIceMaterial();
+    }
+}

--- a/Assets/Scripts/GameHUD.cs
+++ b/Assets/Scripts/GameHUD.cs
@@ -1,0 +1,129 @@
+using System;
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+
+public class GameHUD : MonoBehaviour
+{
+    [SerializeField] PlayerController player;
+    [SerializeField] TextMeshProUGUI displayText;
+
+    float startTime;
+    int recordedFalls;
+    bool subscribed;
+
+    void Awake()
+    {
+        TryFindPlayer();
+        EnsureUi();
+    }
+
+    void OnEnable()
+    {
+        startTime = Time.time;
+        Subscribe();
+    }
+
+    void OnDisable()
+    {
+        Unsubscribe();
+    }
+
+    void OnDestroy()
+    {
+        Unsubscribe();
+    }
+
+    void Update()
+    {
+        if (player == null)
+        {
+            TryFindPlayer();
+            Subscribe();
+        }
+
+        if (displayText == null || player == null)
+        {
+            return;
+        }
+
+        float height = player.transform.position.y;
+        TimeSpan elapsed = TimeSpan.FromSeconds(Mathf.Max(0f, Time.time - startTime));
+        displayText.text = $"Height: {height:0.0}m   Falls: {recordedFalls}   Time: {elapsed:hh\\:mm\\:ss}";
+    }
+
+    void TryFindPlayer()
+    {
+        if (player == null)
+        {
+            player = FindObjectOfType<PlayerController>();
+            if (player != null)
+            {
+                recordedFalls = player.FallCount;
+            }
+        }
+    }
+
+    void Subscribe()
+    {
+        if (player != null && !subscribed)
+        {
+            player.Respawned += OnPlayerRespawned;
+            recordedFalls = player.FallCount;
+            subscribed = true;
+        }
+    }
+
+    void Unsubscribe()
+    {
+        if (player != null && subscribed)
+        {
+            player.Respawned -= OnPlayerRespawned;
+            subscribed = false;
+        }
+    }
+
+    void OnPlayerRespawned(int count)
+    {
+        recordedFalls = count;
+    }
+
+    void EnsureUi()
+    {
+        if (displayText != null)
+        {
+            return;
+        }
+
+        Canvas canvas = GetComponentInChildren<Canvas>();
+        if (canvas == null)
+        {
+            GameObject canvasObj = new GameObject("HUD Canvas");
+            canvasObj.transform.SetParent(transform, false);
+            canvasObj.layer = gameObject.layer;
+
+            canvas = canvasObj.AddComponent<Canvas>();
+            canvas.renderMode = RenderMode.ScreenSpaceOverlay;
+
+            var scaler = canvasObj.AddComponent<CanvasScaler>();
+            scaler.uiScaleMode = CanvasScaler.ScaleMode.ScaleWithScreenSize;
+            scaler.referenceResolution = new Vector2(1920, 1080);
+
+            canvasObj.AddComponent<GraphicRaycaster>();
+        }
+
+        GameObject textObj = new GameObject("HUD Text");
+        textObj.transform.SetParent(canvas.transform, false);
+        displayText = textObj.AddComponent<TextMeshProUGUI>();
+        displayText.enableWordWrapping = false;
+        displayText.fontSize = 32f;
+        displayText.alignment = TextAlignmentOptions.TopLeft;
+        displayText.text = "Height: 0.0m   Falls: 0   Time: 00:00:00";
+
+        var rect = displayText.rectTransform;
+        rect.anchorMin = new Vector2(0f, 1f);
+        rect.anchorMax = new Vector2(0f, 1f);
+        rect.pivot = new Vector2(0f, 1f);
+        rect.anchoredPosition = new Vector2(24f, -24f);
+    }
+}

--- a/Assets/Scripts/LevelBootstrap.cs
+++ b/Assets/Scripts/LevelBootstrap.cs
@@ -1,0 +1,241 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+public class LevelBootstrap : MonoBehaviour
+{
+    [Header("Course Layout")]
+    [SerializeField] int minPlatforms = 8;
+    [SerializeField] int maxPlatforms = 10;
+    [SerializeField] Vector2 heightStepRange = new Vector2(1.1f, 1.9f);
+    [SerializeField] Vector2 forwardStepRange = new Vector2(2.5f, 3.8f);
+    [SerializeField] Vector2 platformSizeRange = new Vector2(2.5f, 4.2f);
+    [SerializeField] float platformThickness = 0.6f;
+    [SerializeField] float lateralSpread = 2.2f;
+    [SerializeField] string generatedRootName = "GeneratedCourseRoot";
+
+    void Start()
+    {
+        Transform root = PrepareRoot();
+        var player = FindObjectOfType<PlayerController>();
+
+        if (player != null && player.GetComponent<PlatformRider>() == null)
+        {
+            player.gameObject.AddComponent<PlatformRider>();
+        }
+
+        if (FindObjectOfType<GameHUD>() == null)
+        {
+            var hudObject = new GameObject("GameHUD");
+            hudObject.AddComponent<GameHUD>();
+        }
+
+        GenerateCourse(root, player);
+    }
+
+    Transform PrepareRoot()
+    {
+        GameObject rootObj = GameObject.Find(generatedRootName);
+        if (rootObj == null)
+        {
+            rootObj = new GameObject(generatedRootName);
+        }
+
+        rootObj.transform.SetParent(transform, false);
+        ClearChildren(rootObj.transform);
+        return rootObj.transform;
+    }
+
+    void ClearChildren(Transform parent)
+    {
+        for (int i = parent.childCount - 1; i >= 0; i--)
+        {
+            var child = parent.GetChild(i);
+            if (Application.isPlaying)
+            {
+                Destroy(child.gameObject);
+            }
+#if UNITY_EDITOR
+            else
+            {
+                DestroyImmediate(child.gameObject);
+            }
+#endif
+        }
+    }
+
+    void GenerateCourse(Transform root, PlayerController player)
+    {
+        if (root == null)
+        {
+            return;
+        }
+
+        int targetCount = Mathf.Clamp(Random.Range(minPlatforms, maxPlatforms + 1), minPlatforms, maxPlatforms);
+        if (targetCount <= 0)
+        {
+            return;
+        }
+
+        Vector3 anchor = Vector3.zero;
+        if (player != null)
+        {
+            anchor = player.respawnPoint != null ? player.respawnPoint.position : player.transform.position;
+        }
+
+        float currentHeight = Mathf.Max(anchor.y + 0.8f, 1f);
+        float currentForward = anchor.z + 4f;
+        float baseX = anchor.x;
+
+        var platforms = new List<GameObject>(targetCount);
+
+        for (int i = 0; i < targetCount; i++)
+        {
+            float heightStep = Random.Range(heightStepRange.x, heightStepRange.y);
+            if (i == 0)
+            {
+                heightStep = Mathf.Clamp(heightStep, heightStepRange.x * 0.5f, heightStepRange.y);
+            }
+
+            currentHeight += heightStep;
+            currentForward += Random.Range(forwardStepRange.x, forwardStepRange.y);
+
+            float lateral = baseX + Random.Range(-lateralSpread, lateralSpread);
+            Vector3 position = new Vector3(lateral, currentHeight, currentForward);
+            float sizeX = Random.Range(platformSizeRange.x, platformSizeRange.y);
+            float sizeZ = Random.Range(platformSizeRange.x, platformSizeRange.y);
+            Vector3 scale = new Vector3(sizeX, platformThickness, sizeZ);
+
+            GameObject platform = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            platform.name = $"Platform_{i:00}";
+            platform.transform.SetParent(root, false);
+            platform.transform.position = position;
+            platform.transform.localScale = scale;
+
+            platforms.Add(platform);
+        }
+
+        if (platforms.Count == 0)
+        {
+            return;
+        }
+
+        int movingIndex = SetupMovingPlatform(platforms, root);
+        SetupIcePlatform(platforms, movingIndex);
+        SetupCheckpoints(platforms, root);
+    }
+
+    int SetupMovingPlatform(List<GameObject> platforms, Transform root)
+    {
+        if (platforms.Count < 2)
+        {
+            return -1;
+        }
+
+        int movingIndex = Mathf.Clamp(platforms.Count / 2, 1, platforms.Count - 1);
+        GameObject platform = platforms[movingIndex];
+        var mover = platform.AddComponent<MovingPlatform>();
+
+        Vector3 basePosition = platform.transform.position;
+        Vector3 travel = new Vector3(2.5f, 0f, 0f);
+
+        var pointAObj = new GameObject(platform.name + "_PointA");
+        pointAObj.transform.SetParent(root, false);
+        pointAObj.transform.position = basePosition - travel * 0.5f;
+
+        var pointBObj = new GameObject(platform.name + "_PointB");
+        pointBObj.transform.SetParent(root, false);
+        pointBObj.transform.position = basePosition + travel * 0.5f;
+
+        mover.pointA = pointAObj.transform;
+        mover.pointB = pointBObj.transform;
+        mover.speed = 2.2f;
+        mover.startAtPointA = true;
+
+        return movingIndex;
+    }
+
+    void SetupIcePlatform(List<GameObject> platforms, int movingIndex)
+    {
+        if (platforms.Count == 0)
+        {
+            return;
+        }
+
+        int iceIndex = Mathf.Max(0, platforms.Count - 2);
+        if (iceIndex == movingIndex)
+        {
+            iceIndex = Mathf.Max(0, iceIndex - 1);
+        }
+
+        GameObject icePlatform = platforms[Mathf.Clamp(iceIndex, 0, platforms.Count - 1)];
+        var collider = icePlatform.GetComponent<Collider>();
+        EnsurePhysicsMaterials.ApplyIce(collider);
+
+        var renderer = icePlatform.GetComponent<Renderer>();
+        if (renderer != null)
+        {
+            var mat = renderer.material;
+            mat.color = new Color(0.6f, 0.8f, 1f, 1f);
+        }
+    }
+
+    void SetupCheckpoints(List<GameObject> platforms, Transform root)
+    {
+        if (platforms.Count < 2)
+        {
+            return;
+        }
+
+        var indices = new HashSet<int>();
+        indices.Add(1);
+        indices.Add(platforms.Count / 2);
+        if (platforms.Count > 4)
+        {
+            indices.Add(Mathf.Max(1, platforms.Count - 2));
+        }
+
+        foreach (int index in indices)
+        {
+            if (index < 0 || index >= platforms.Count)
+            {
+                continue;
+            }
+
+            GameObject platform = platforms[index];
+            Vector3 platformTop = platform.transform.position + Vector3.up * (platform.transform.localScale.y * 0.5f + 0.8f);
+
+            GameObject checkpointRoot = new GameObject($"Checkpoint_{index:00}");
+            checkpointRoot.transform.SetParent(root, false);
+            checkpointRoot.transform.position = platformTop;
+            checkpointRoot.transform.localScale = Vector3.one * 0.8f;
+
+            var trigger = checkpointRoot.AddComponent<SphereCollider>();
+            trigger.isTrigger = true;
+            trigger.radius = 0.6f;
+            checkpointRoot.AddComponent<Checkpoint>();
+
+            CreateCheckpointVisual(checkpointRoot.transform);
+        }
+    }
+
+    void CreateCheckpointVisual(Transform parent)
+    {
+        GameObject visual = GameObject.CreatePrimitive(PrimitiveType.Cylinder);
+        visual.name = "Marker";
+        visual.transform.SetParent(parent, false);
+        visual.transform.localScale = new Vector3(0.3f, 1.2f, 0.3f);
+
+        var renderer = visual.GetComponent<Renderer>();
+        if (renderer != null)
+        {
+            var mat = renderer.material;
+            mat.color = new Color(1f, 0.8f, 0.2f, 1f);
+        }
+
+        var collider = visual.GetComponent<Collider>();
+        if (collider != null)
+        {
+            Destroy(collider);
+        }
+    }
+}

--- a/Assets/Scripts/MovingPlatform.cs
+++ b/Assets/Scripts/MovingPlatform.cs
@@ -1,0 +1,71 @@
+using UnityEngine;
+
+public class MovingPlatform : MonoBehaviour
+{
+    public Transform pointA;
+    public Transform pointB;
+    public float speed = 2f;
+    public bool startAtPointA = true;
+
+    Vector3 targetPosition;
+    bool movingToB;
+    bool warnedMissingPoints;
+
+    void Start()
+    {
+        if (!HasValidPoints())
+        {
+            return;
+        }
+
+        movingToB = startAtPointA;
+        transform.position = startAtPointA ? pointA.position : pointB.position;
+        targetPosition = movingToB ? pointB.position : pointA.position;
+    }
+
+    void Update()
+    {
+        if (!HasValidPoints())
+        {
+            return;
+        }
+
+        float step = speed * Time.deltaTime;
+        transform.position = Vector3.MoveTowards(transform.position, targetPosition, step);
+
+        if (Vector3.SqrMagnitude(transform.position - targetPosition) < 0.0001f)
+        {
+            movingToB = !movingToB;
+            targetPosition = movingToB ? pointB.position : pointA.position;
+        }
+    }
+
+    bool HasValidPoints()
+    {
+        if (pointA == null || pointB == null)
+        {
+            if (!warnedMissingPoints)
+            {
+                Debug.LogWarning("MovingPlatform requires both pointA and pointB.", this);
+                warnedMissingPoints = true;
+            }
+            return false;
+        }
+
+        warnedMissingPoints = false;
+        return true;
+    }
+
+    void OnDrawGizmosSelected()
+    {
+        if (pointA == null || pointB == null)
+        {
+            return;
+        }
+
+        Gizmos.color = Color.cyan;
+        Gizmos.DrawLine(pointA.position, pointB.position);
+        Gizmos.DrawSphere(pointA.position, 0.1f);
+        Gizmos.DrawSphere(pointB.position, 0.1f);
+    }
+}

--- a/Assets/Scripts/PlatformRider.cs
+++ b/Assets/Scripts/PlatformRider.cs
@@ -1,0 +1,68 @@
+using UnityEngine;
+
+[RequireComponent(typeof(Rigidbody))]
+public class PlatformRider : MonoBehaviour
+{
+    Transform defaultParent;
+    MovingPlatform currentPlatform;
+
+    void Awake()
+    {
+        defaultParent = transform.parent;
+    }
+
+    void OnCollisionEnter(Collision collision)
+    {
+        TryAttach(collision.transform);
+    }
+
+    void OnCollisionStay(Collision collision)
+    {
+        TryAttach(collision.transform);
+    }
+
+    void OnCollisionExit(Collision collision)
+    {
+        if (currentPlatform == null)
+        {
+            return;
+        }
+
+        var platform = collision.transform.GetComponentInParent<MovingPlatform>();
+        if (platform == currentPlatform)
+        {
+            Detach();
+        }
+    }
+
+    void OnDisable()
+    {
+        Detach();
+    }
+
+    void TryAttach(Transform other)
+    {
+        var platform = other.GetComponentInParent<MovingPlatform>();
+        if (platform == null)
+        {
+            return;
+        }
+
+        if (currentPlatform == platform)
+        {
+            return;
+        }
+
+        currentPlatform = platform;
+        transform.SetParent(platform.transform, true);
+    }
+
+    void Detach()
+    {
+        if (currentPlatform != null)
+        {
+            currentPlatform = null;
+            transform.SetParent(defaultParent, true);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add checkpoint triggers that update the player's respawn point and visualise activation state
- stabilise player respawn handling, add HUD statistics, and ensure slippery physics materials exist at runtime
- generate a simple vertical course with moving and icy platforms while wiring the player to ride movers naturally

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68cf6c69770c8322994e7c1caf6b9018